### PR TITLE
optimal performance

### DIFF
--- a/src/lib/SplitPane.tsx
+++ b/src/lib/SplitPane.tsx
@@ -161,7 +161,11 @@ function useSplitPaneResize(options: SplitPaneResizeOptions): {
 
 	useEffect(() => {
 		if (onChange && dragState) {
-			onChange(movedSizes);
+			if (window.requestAnimationFrame) {
+				window.requestAnimationFrame(() => onChange(movedSizes))
+			} else {
+				setTimeout(() => onChange(movedSizes), 66)
+			}
 		}
 	}, [dragState, movedSizes, onChange]);
 


### PR DESCRIPTION
When I used the onchange argument to resize the view,react reported the following error. 

![image](https://user-images.githubusercontent.com/22909744/145242132-7abf4b12-6504-4ac0-a676-d8e53509c948.png)

I thought it needed to optimize the performance. I've tested it locally and it works fine.