### PR TITLE
feat: add custom className to resizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ Additional CSS class name that is appied to all elements rendered by the
 SplitPane. For a class name `custom`, the individual elements can be selected as
 `.SplitPane.custom`, `.Resizer.custom`, and `.Pane.custom`.
 
+### resizerClassName: string
+Additional CSS class name that is appied only to the resizer rendered by the
+SplitPane.
+
 ### onDragStarted: () => void
 This callback is invoked when a drag starts.
 

--- a/src/lib/SplitPane.tsx
+++ b/src/lib/SplitPane.tsx
@@ -10,6 +10,7 @@ const DEFAULT_MIN_SIZE = 50;
 export interface SplitPaneProps {
 	split?: 'horizontal' | 'vertical';
 	className?: string;
+	resizerClassName?: string;
 
 	children: React.ReactChild[];
 
@@ -216,7 +217,7 @@ function useSplitPaneResize(options: SplitPaneResizeOptions): {
 
 export const SplitPane = React.memo((props: SplitPaneProps) => {
 	const options = { ...defaultProps, ...props };
-	const { split, className } = options;
+	const { split, className, resizerClassName } = options;
 
 	const { childPanes, resizeState, handleDragStart } = useSplitPaneResize(options);
 
@@ -265,7 +266,11 @@ export const SplitPane = React.memo((props: SplitPaneProps) => {
 				<Resizer
 					key={'resizer.' + index}
 					split={split}
-					className={className + (resizing ? ' resizing' : '')}
+					className={
+						className +
+						(resizing ? ' resizing' : '') +
+						(resizerClassName ? ` ${resizerClassName}` : ``)
+					}
 					index={index - 1}
 					onDragStarted={handleDragStart}
 				/>,


### PR DESCRIPTION
This PR adds the ability to add a custom className on only the resizer. The reason for adding this is to be able to use Tailwind CSS to style the resizer rather than writing CSS. 

--------

Thanks for contributing to react-split-pane!

**Before submitting a pull request,** please complete the following checklist:

- [ ] The existing test suites (`yarn test`) all pass
- [ ] For any new features or bug fixes, both positive and negative test cases have been added
- [x] For any new features, documentation has been added
- [x] For any documentation changes, the text has been proofread and is clear to both experienced users and beginners.
- [x] Format your code with [prettier](https://github.com/prettier/prettier) (`npm run prettier`).

Here is a short checklist of additional things to keep in mind before submitting:
* Please make sure your pull request description makes it very clear what you're trying to accomplish. If it's a bug fix, please also provide a failing test case (if possible). In either case, please add additional unit test coverage for your changes. :)
* Be sure you have notifications setup so that you'll see my code review responses. (I may ask you to make some adjustments before merging.)
