### PR TITLE
Added event listener for end of a touch

### DIFF
--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -101,6 +101,7 @@ export function useDragState<T>(
 	useEventListener('mousemove', onMouseMove);
 	useEventListener('touchmove', onTouchMove);
 	useEventListener('mouseup', onMouseUp);
+	useEventListener('touchend', onMouseUp);
 
 	return [dragState, beginDrag];
 }


### PR DESCRIPTION
There is some error when using resizing on the touch screen occurs after dragging is completed. This edit fixes this issue.